### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,13 @@
 [node-src]: https://img.shields.io/node/v/@f2c/mcp?style=flat&colorA=18181B&colorB=F0DB4F
 [node-href]: https://nodejs.org/en/about/previous-releases
 
-English | [简体中文](./README-zh-CN.md) 
+English | [简体中文](./README-zh-CN.md)
 
 <img alt="f2c" src="https://raw.githubusercontent.com/f2c-ai/f2c-mcp/main/docs/bannerv3.png" />
+
+<a href="https://glama.ai/mcp/servers/@f2c-ai/f2c-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@f2c-ai/f2c-mcp/badge" alt="f2c-mcp-server MCP server" />
+</a>
 
 The F2C MCP Server is a Model Context Protocol server that enables AI coding assistants to access Figma design data and convert it to HTML/CSS code. Key features:
 


### PR DESCRIPTION
This PR adds a badge for the [f2c-mcp-server](https://glama.ai/mcp/servers/@f2c-ai/f2c-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@f2c-ai/f2c-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@f2c-ai/f2c-mcp/badge" alt="f2c-mcp-server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.